### PR TITLE
Support of Spree: 3-1-stable

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,4 @@
 --color
+-f documentation
+-r spec_helper
+-r pry

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: ruby
+rvm:
+  - 2.2
+  - 2.3.3
+sudo: false
+cache: bundler
+before_script:
+  - bundle exec rake test_app
+script:
+  - bundle exec rspec spec

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,5 @@
 source 'https://rubygems.org'
 
-gem 'spree', github: 'spree/spree', branch: '3-0-stable'
-# Provides basic authentication functionality for testing parts of your engine
-gem 'spree_auth_devise', github: 'spree/spree_auth_devise', branch: '3-0-stable'
+gem 'spree', github: 'spree/spree', branch: '3-1-stable'
 
 gemspec

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 SpreeAbandonedCarts
 ===================
 
-Take some action for abandoned carts.
+Take some action for abandoned (incompleted) carts.
 
 Override `Spree::Order#abandoned_cart_actions` with your logic.
 By default an email is sent, see `AbandonedCartMailer`.
@@ -33,8 +33,6 @@ There are some preferences you can change (defaults are shown here):
 
 ```ruby
 SpreeAbandonedCarts::Config.tap do |config|
-  # order states to check for abandonment
-  config.abandoned_states = [:cart, :address, :delivery, :payment, :confirm]
   # when an order can be marked as abandoned
   config.abandoned_after_minutes = 1440 # 24 hours
   # how often the sidekiq worker should run

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-[![Build Status](https://travis-ci.org/ssnickolay/spree_abandoned_cart_email.svg?branch=3-1-stable)](https://travis-ci.org/ssnickolay/spree_abandoned_cart_email)
-[![Gem Version](https://badge.fury.io/rb/spree_abandoned_cart_email.svg)](http://badge.fury.io/rb/spree_abandoned_cart_email)
+[![Build Status](https://travis-ci.org/ssnickolay/spree_abandoned_carts.svg?branch=3-1-stable)](https://travis-ci.org/ssnickolay/spree_abandoned_carts)
 
 SpreeAbandonedCarts
 ===================

--- a/README.md
+++ b/README.md
@@ -42,9 +42,20 @@ SpreeAbandonedCarts::Config.tap do |config|
 end
 ```
 
+You can perform the processing of the abandoned carts at any time:
+
+```ruby
+Spree::AbandonedCartService.perform
+```
+
+or use the auto processing solution (based on Sidekiq):
+
+```ruby
+Spree::AbandonedCartWorker.perfrom
+```
+
 To modify the email, you just have to override `Spree.t(:abandoned_cart_subject)`
 and `app/views/spree/abandoned_cart_mailer/abandoned_cart_email.html.erb`.
-
 
 Testing
 -------
@@ -63,4 +74,4 @@ Simply add this require statement to your spec_helper:
 require 'spree_abandoned_carts/factories'
 ```
 
-Copyright (c) 2015 Alessandro Lepore, released under the New BSD License
+Copyright (c) 2015-2017 Alessandro Lepore, released under the New BSD License

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+[![Build Status](https://travis-ci.org/ssnickolay/spree_abandoned_cart_email.svg?branch=3-1-stable)](https://travis-ci.org/ssnickolay/spree_abandoned_cart_email)
+[![Gem Version](https://badge.fury.io/rb/spree_abandoned_cart_email.svg)](http://badge.fury.io/rb/spree_abandoned_cart_email)
+
 SpreeAbandonedCarts
 ===================
 

--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -12,7 +12,7 @@ module Spree
       -> { abandoned.where(abandoned_cart_email_sent_at: nil) }
 
     def abandoned_cart_actions
-      AbandonedCartMailer.abandoned_cart_email(self).deliver
+      AbandonedCartMailer.abandoned_cart_email(self).deliver_now
       touch(:abandoned_cart_email_sent_at)
     end
 

--- a/app/services/abandoned_cart_service.rb
+++ b/app/services/abandoned_cart_service.rb
@@ -1,0 +1,10 @@
+class AbandonedCartService
+  class << self
+    def perform
+      Spree::Order.abandon_not_notified.each do |order|
+        next unless order.last_for_user?
+        order.abandoned_cart_actions
+      end
+    end
+  end
+end

--- a/app/workers/abandoned_cart_worker.rb
+++ b/app/workers/abandoned_cart_worker.rb
@@ -2,10 +2,7 @@ class AbandonedCartWorker
   include Sidekiq::Worker if defined?(Sidekiq)
 
   def perform
-    Spree::Order.abandon_not_notified.each do |order|
-      next unless order.last_for_user?
-      order.abandoned_cart_actions
-    end
+    AbandonedCartService.perform
 
     if self.class.respond_to?(:perform_in)
       next_run = SpreeAbandonedCarts::Config.worker_frequency_minutes

--- a/lib/spree_abandoned_carts/configuration.rb
+++ b/lib/spree_abandoned_carts/configuration.rb
@@ -1,7 +1,7 @@
 module SpreeAbandonedCarts
   class Configuration < Spree::Preferences::Configuration
     preference :abandoned_states, :array, default: [:cart, :address, :delivery, :payment, :confirm]
-    preference :abandoned_after_minutes, :integer, default: 1440
-    preference :worker_frequency_minutes, :integer, default: 30
+    preference :abandoned_after_minutes, :integer, default: 24.hours / 1.minute
+    preference :worker_frequency_minutes, :integer, default: 30.minutes
   end
 end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -1,0 +1,54 @@
+RSpec.describe Spree::Order do
+  let(:abandoned_time) { Time.current - SpreeAbandonedCarts::Config.abandoned_after_minutes.minutes - 1.second }
+  let!(:abandoned_order) { create(:order, updated_at: abandoned_time, item_total: 100) }
+
+  describe '.abandoned' do
+    let!(:fresh_order) { create(:order, item_total: 100) }
+    let!(:empty_order) { create(:order, updated_at: abandoned_time, item_total: 0) }
+    let!(:order_without_email) do
+      create(:order, updated_at: abandoned_time, item_total: 100).update_attributes(email: nil)
+    end
+
+    subject { described_class.abandoned }
+
+    it { is_expected.to match_array([abandoned_order]) }
+  end
+
+  describe '.abandon_not_notified' do
+    let!(:notified_abandoned_order) do
+      create(:order, updated_at: abandoned_time, item_total: 100, abandoned_cart_email_sent_at: Time.now)
+    end
+
+    subject { described_class.abandon_not_notified }
+
+    it { is_expected.to match_array([abandoned_order]) }
+  end
+
+  describe '#abandoned_cart_actions' do
+    subject { abandoned_order.abandoned_cart_actions }
+
+    it 'should receive abandoned_cart_email' do
+      expect(Spree::AbandonedCartMailer).to receive(:abandoned_cart_email).with(abandoned_order).and_call_original
+
+      subject
+    end
+
+    it 'should set #abandoned_cart_email_sent_at' do
+      expect { subject }.to change { abandoned_order.abandoned_cart_email_sent_at }
+    end
+  end
+
+  describe '#last_for_user?' do
+    subject { abandoned_order.last_for_user? }
+
+    context 'when user has not another orders' do
+      it { is_expected.to be_truthy }
+    end
+
+    context 'when user has a new order' do
+      before { create(:order).update_attributes(email: abandoned_order.email) }
+
+      it { is_expected.to be_falsey }
+    end
+  end
+end

--- a/spec/services/abandoned_cart_service_spec.rb
+++ b/spec/services/abandoned_cart_service_spec.rb
@@ -1,0 +1,15 @@
+RSpec.describe Spree::AbandonedCartService do
+  let!(:abandoned_order) { create(:order, item_total: 1_00) }
+
+  describe '#perform' do
+    let(:future) { Time.current + SpreeAbandonedCarts::Config.abandoned_after_minutes.minutes + 1.second }
+
+    it 'should touch abandoned order' do
+      travel_to future do
+        expect(Spree::AbandonedCartMailer).to receive(:abandoned_cart_email).with(abandoned_order).and_call_original
+
+        expect { described_class.perform }.to change { abandoned_order.reload.abandoned_cart_email_sent_at }
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,11 +2,7 @@
 require 'simplecov'
 SimpleCov.start do
   add_filter 'spec/dummy'
-  add_group 'Controllers', 'app/controllers'
-  add_group 'Helpers', 'app/helpers'
-  add_group 'Mailers', 'app/mailers'
   add_group 'Models', 'app/models'
-  add_group 'Views', 'app/views'
   add_group 'Libraries', 'lib'
 end
 
@@ -18,6 +14,7 @@ require File.expand_path('../dummy/config/environment.rb',  __FILE__)
 require 'rspec/rails'
 require 'database_cleaner'
 require 'ffaker'
+require 'active_support/testing/time_helpers'
 
 # Requires supporting ruby files with custom matchers and macros, etc,
 # in spec/support/ and its subdirectories.
@@ -25,32 +22,11 @@ Dir[File.join(File.dirname(__FILE__), 'support/**/*.rb')].each { |f| require f }
 
 # Requires factories defined in spree_core
 require 'spree/testing_support/factories'
-require 'spree/testing_support/controller_requests'
-require 'spree/testing_support/authorization_helpers'
-require 'spree/testing_support/url_helpers'
-
-# Requires factories defined in lib/spree_abandoned_carts/factories.rb
-require 'spree_abandoned_carts/factories'
 
 RSpec.configure do |config|
   config.include FactoryGirl::Syntax::Methods
+  config.include ActiveSupport::Testing::TimeHelpers
 
-  # == URL Helpers
-  #
-  # Allows access to Spree's routes in specs:
-  #
-  # visit spree.admin_path
-  # current_path.should eql(spree.products_path)
-  config.include Spree::TestingSupport::UrlHelpers
-
-  # == Mock Framework
-  #
-  # If you prefer to use mocha, flexmock or RR, uncomment the appropriate line:
-  #
-  # config.mock_with :mocha
-  # config.mock_with :flexmock
-  # config.mock_with :rr
-  config.mock_with :rspec
   config.color = true
 
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
@@ -69,7 +45,7 @@ RSpec.configure do |config|
 
   # Before each spec check if it is a Javascript test and switch between using database transactions or not where necessary.
   config.before :each do
-    DatabaseCleaner.strategy = example.metadata[:js] ? :truncation : :transaction
+    DatabaseCleaner.strategy = :transaction
     DatabaseCleaner.start
   end
 
@@ -79,5 +55,5 @@ RSpec.configure do |config|
   end
 
   config.fail_fast = ENV['FAIL_FAST'] || false
-  config.order = "random"
+  config.order = 'random'
 end

--- a/spree_abandoned_carts.gemspec
+++ b/spree_abandoned_carts.gemspec
@@ -16,16 +16,12 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.requirements << 'none'
 
-  s.add_dependency 'spree_core', '~> 3.0.0'
+  s.add_dependency 'spree_core', '~> 3.1'
 
-  s.add_development_dependency 'capybara', '~> 2.4'
-  s.add_development_dependency 'coffee-rails'
   s.add_development_dependency 'database_cleaner'
-  s.add_development_dependency 'factory_girl', '~> 4.4'
+  s.add_development_dependency 'factory_girl', '~> 4'
   s.add_development_dependency 'ffaker'
-  s.add_development_dependency 'rspec-rails',  '~> 3.1'
-  s.add_development_dependency 'sass-rails', '~> 4.0.2'
-  s.add_development_dependency 'selenium-webdriver'
+  s.add_development_dependency 'rspec-rails', '~> 3'
   s.add_development_dependency 'simplecov'
   s.add_development_dependency 'sqlite3'
 end

--- a/spree_abandoned_carts.gemspec
+++ b/spree_abandoned_carts.gemspec
@@ -19,9 +19,12 @@ Gem::Specification.new do |s|
   s.add_dependency 'spree_core', '~> 3.1'
 
   s.add_development_dependency 'database_cleaner'
-  s.add_development_dependency 'factory_girl', '~> 4'
+  s.add_development_dependency 'factory_girl', '~> 4.5'
   s.add_development_dependency 'ffaker'
-  s.add_development_dependency 'rspec-rails', '~> 3'
+  s.add_development_dependency 'rspec-rails', '~> 3.3'
   s.add_development_dependency 'simplecov'
+  s.add_development_dependency 'coffee-rails', '~> 4.0.0'
+  s.add_development_dependency 'sass-rails', '~> 5.0.0'
+  s.add_development_dependency 'pry-rails', '>= 0.3.2'
   s.add_development_dependency 'sqlite3'
 end


### PR DESCRIPTION
1. Upped spree version to 3.1.
2. Moved the processing logic to a separate service (for ease of use).
3. Added tests.
4. Added Travis-CI integration (please, register the gem in Travis after merge, and replace README links to your account). 
